### PR TITLE
Update controls_screen.dart

### DIFF
--- a/lib/src/tutorial/controls_screen.dart
+++ b/lib/src/tutorial/controls_screen.dart
@@ -53,8 +53,8 @@ class ControlsScreen extends TutorialDialog {
 			..addView(movementOrView)
 			..addView(aView)
 			..addView(sView)
-			..addView(dView)
 			..addView(wView)
+			..addView(dView)
 			..addView(cView);
 
         pauseView


### PR DESCRIPTION
Altered the control screen portion of the tutorial to display w a s d controls in the same order as the arrow controls.
